### PR TITLE
Update 15-5.scm

### DIFF
--- a/15-advanced-recursion/15-5.scm
+++ b/15-advanced-recursion/15-5.scm
@@ -23,7 +23,7 @@
         ((= n 7) (se 'p 'q 'r 's))
         ((= n 8) (se 't 'u 'v))
         ((= n 9) (se 'w 'x 'y 'z))
-        (else (letters 2))))
+        (else n)))
 
 (define (prepend-every letter sent)
   (if (empty? sent)
@@ -33,13 +33,13 @@
 
 (define (prepend-each a b)
   (if (empty? a)
-    b
+    '()
     (se (prepend-each (bf a) b)
         (prepend-every (first a) b))))
 
 (define (phone-spell n)
-  (if (= (count n) 1)
-    (letters n)
+  (if (empty? n)
+    (se "")
     (se
       (prepend-each (letters (first n))
                     (phone-spell (bf n))))))


### PR DESCRIPTION
Making the base case of prepend-each return an empty sentence makes the program work correctly.

Since 0 and 1 don't correspond to letters, if you want to leave 0s and 1s in the spellings, letters should return the value associated with n if the value associated with n is not between 2 and 9.

It is also possible to use an empty word as the base case for phone-spell.